### PR TITLE
Add custom composer filename setting

### DIFF
--- a/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsComponent.kt
+++ b/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsComponent.kt
@@ -14,6 +14,7 @@ class ProjectSettingsComponent {
     private var settingsPanel: JPanel
     private val laravelRootTextField = TextFieldWithBrowseButton()
     private val vendorRootTextField = TextFieldWithBrowseButton()
+    private val composerFilenameTextField = JBTextField()
     private val terminateAppCheckBox = JBCheckBox(Strings.get("lt.settings.terminate_app"))
 
     var laravelRoot: String
@@ -25,6 +26,11 @@ class ProjectSettingsComponent {
         get() = this.vendorRootTextField.text
         set(value) {
             this.vendorRootTextField.text = value
+        }
+    var composerFilename: String
+        get() = this.composerFilenameTextField.text
+        set(value) {
+            this.composerFilenameTextField.text = value
         }
     var terminateApp: Boolean
         get() = this.terminateAppCheckBox.isSelected
@@ -54,6 +60,7 @@ class ProjectSettingsComponent {
                 .addTooltip(Strings.get("lt.settings.laravel_root.tooltip1"))
                 .addTooltip(Strings.get("lt.settings.laravel_root.tooltip2"))
                 .addTooltip(Strings.get("lt.settings.laravel_root.tooltip3"))
+                .addComponent(composerFilenameTextField)
                 .addComponent(terminateAppCheckBox)
                 .addComponentFillVertically(JPanel(), 0)
                 .panel

--- a/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsConfigurable.kt
@@ -17,7 +17,8 @@ class ProjectSettingsConfigurable(private var project: Project) : Configurable {
         val projectSettings = ProjectSettingsState.getInstance(project)
         return projectSettingsComponent!!.laravelRoot != projectSettings.laravelRoot ||
             projectSettingsComponent!!.terminateApp != projectSettings.terminateApp ||
-            projectSettingsComponent!!.vendorRoot != projectSettings.vendorRoot
+            projectSettingsComponent!!.vendorRoot != projectSettings.vendorRoot ||
+            projectSettingsComponent!!.composerFilename != projectSettings.composerFilename
     }
 
     override fun apply() {
@@ -25,6 +26,7 @@ class ProjectSettingsConfigurable(private var project: Project) : Configurable {
         projectSettings.laravelRoot = projectSettingsComponent!!.laravelRoot
         projectSettings.terminateApp = projectSettingsComponent!!.terminateApp
         projectSettings.vendorRoot = projectSettingsComponent!!.vendorRoot
+        projectSettings.composerFilename = projectSettingsComponent!!.composerFilename
     }
 
     override fun reset() {
@@ -32,6 +34,7 @@ class ProjectSettingsConfigurable(private var project: Project) : Configurable {
         projectSettingsComponent!!.laravelRoot = projectSettings.laravelRoot
         projectSettingsComponent!!.terminateApp = projectSettings.terminateApp
         projectSettingsComponent!!.vendorRoot = projectSettings.vendorRoot
+        projectSettingsComponent!!.composerFilename = projectSettings.composerFilename
     }
 
     override fun getDisplayName(): String {

--- a/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsState.kt
+++ b/src/main/kotlin/nl/deschepers/laraveltinker/settings/ProjectSettingsState.kt
@@ -16,6 +16,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class ProjectSettingsState : PersistentStateComponent<ProjectSettingsState> {
     var laravelRoot = ""
     var vendorRoot = ""
+    var composerFilename = "composer.json"
     var terminateApp = false
 
     companion object {
@@ -39,8 +40,13 @@ class ProjectSettingsState : PersistentStateComponent<ProjectSettingsState> {
             this.vendorRoot = this.laravelRoot
         }
 
+        if (this.composerFilename.isEmpty()) {
+            this.composerFilename = "composer.json"
+        }
+
         settingsObject.addProperty("laravelRoot", this.laravelRoot)
         settingsObject.addProperty("vendorRoot", this.vendorRoot)
+        settingsObject.addProperty("composerFilename", this.composerFilename)
         settingsObject.addProperty("terminateApp", this.terminateApp)
         return settingsObject
     }

--- a/src/main/resources/scripts/tinker_run.php
+++ b/src/main/resources/scripts/tinker_run.php
@@ -11,7 +11,7 @@ echo "%%START-OUTPUT%%";
 
 $projectSettings = json_decode($argv[2]) ?? new stdClass();
 
-$composerJsonFile = ($projectSettings->vendorRoot ?: __DIR__) . '/composer.json';
+$composerJsonFile = ($projectSettings->vendorRoot ?: __DIR__) . '/'. ($projectSettings->composerFilename ?: 'composer.json');
 if (!file_exists($composerJsonFile)) {
     throw new Exception($composerJsonFile . ' does not exist. Please check your project settings.');
 }


### PR DESCRIPTION
Allow setting an alternate filename for composer.json

(TODO: refactor if actually useful to use the PHPStorm project-level composer path setting if set)